### PR TITLE
Adding VNetSubnet Validator, raise Error if we got an invalid resourc…

### DIFF
--- a/src/aks-preview/azext_aks_preview/_client_factory.py
+++ b/src/aks-preview/azext_aks_preview/_client_factory.py
@@ -62,6 +62,8 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
         matched = re.match('/subscriptions/(?P<subscription>[^/]*)/', scope)
         if matched:
             subscription_id = matched.groupdict()['subscription']
+        else:
+            raise CLIError("{} does not contain subscription Id.".format(scope))
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION, subscription_id=subscription_id)
 
 

--- a/src/aks-preview/azext_aks_preview/_params.py
+++ b/src/aks-preview/azext_aks_preview/_params.py
@@ -20,7 +20,7 @@ from ._validators import (
     validate_ssh_key, validate_max_pods, validate_nodes_count, validate_ip_ranges,
     validate_nodepool_name, validate_vm_set_type, validate_load_balancer_sku,
     validate_load_balancer_outbound_ips, validate_load_balancer_outbound_ip_prefixes,
-    validate_taints, validate_priority, validate_eviction_policy, validate_acr, validate_user)
+    validate_taints, validate_priority, validate_eviction_policy, validate_acr, validate_user, validate_vnet_subnet_id)
 
 
 def load_arguments(self, _):
@@ -70,7 +70,7 @@ def load_arguments(self, _):
         c.argument('no_ssh_key', options_list=['--no-ssh-key', '-x'])
         c.argument('pod_cidr')
         c.argument('service_cidr')
-        c.argument('vnet_subnet_id')
+        c.argument('vnet_subnet_id', type=str, validator=validate_vnet_subnet_id)
         c.argument('workspace_resource_id')
         c.argument('skip_subnet_role_assignment', action='store_true')
         c.argument('enable_cluster_autoscaler', action='store_true')

--- a/src/aks-preview/azext_aks_preview/_validators.py
+++ b/src/aks-preview/azext_aks_preview/_validators.py
@@ -219,3 +219,9 @@ def validate_user(namespace):
     if namespace.user.lower() != "clusteruser" and \
             namespace.user.lower() != "clustermonitoringuser":
         raise CLIError("--user can only be clusterUser or clusterMonitoringUser")
+
+
+def validate_vnet_subnet_id(namespace):
+    from msrestazure.tools import is_valid_resource_id
+    if not is_valid_resource_id(namespace.vnet_subnet_id):
+        raise CLIError("--vnet-subnet-id is not a valid Azure resource ID.")

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
@@ -76,6 +76,10 @@ class TestVNetSubnetId(unittest.TestCase):
             validators.validate_vnet_subnet_id(namespace)
         self.assertEqual(str(cm.exception), err)
 
+    def test_valid_vnet_subnet_id(self):
+        invalid_vnet_subnet_id = "/subscriptions/testid/resourceGroups/MockedResourceGroup/providers/Microsoft.Network/virtualNetworks/MockedNetworkId/subnets/MockedSubNetId"
+        namespace = VnetSubnetIdNamespace(invalid_vnet_subnet_id)
+        validators.validate_vnet_subnet_id(namespace)
 
 class VnetSubnetIdNamespace:
     def __init__(self, vnet_subnet_id):

--- a/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
+++ b/src/aks-preview/azext_aks_preview/tests/latest/test_validators.py
@@ -64,3 +64,19 @@ class TestValidateIPRanges(unittest.TestCase):
 class Namespace:
     def __init__(self, api_server_authorized_ip_ranges):
         self.api_server_authorized_ip_ranges = api_server_authorized_ip_ranges
+
+
+class TestVNetSubnetId(unittest.TestCase):
+    def test_invalid_vnet_subnet_id(self):
+        invalid_vnet_subnet_id = "dummy subnet id"
+        namespace = VnetSubnetIdNamespace(invalid_vnet_subnet_id)
+        err = ("--vnet-subnet-id is not a valid Azure resource ID.")
+
+        with self.assertRaises(CLIError) as cm:
+            validators.validate_vnet_subnet_id(namespace)
+        self.assertEqual(str(cm.exception), err)
+
+
+class VnetSubnetIdNamespace:
+    def __init__(self, vnet_subnet_id):
+        self.vnet_subnet_id = vnet_subnet_id


### PR DESCRIPTION
Add vnetSubnet validation to azure-cli aks-preview and acs module.
Throw out an error if the input is invalid.
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [X ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
